### PR TITLE
Hotfix: update link to api-tools page in footer

### DIFF
--- a/theme/partials/footer.html
+++ b/theme/partials/footer.html
@@ -14,7 +14,7 @@
                 <ul>
                     <li>Laminas Project <a href="https://getlaminas.org/">Components and MVC for Enterprise Applications</a></li>
                     <li>Mezzio <a href="https://getmezzio.org/">PSR-15 Middleware in Minutes</a></li>
-                    <li>Laminas API Tools: <a href="https://api-tools.laminas.dev/">Build RESTful APIs in minutes</a></li>
+                    <li>Laminas API Tools: <a href="https://api-tools.getlaminas.org/">Build RESTful APIs in minutes</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
Not sure if this change is enough to change the link in all places - see:
https://github.com/search?q=org%3Alaminas+api-tools.laminas.dev&type=Code