### PR TITLE
Hotfix: update theme to use laminas references instead of zendframework

### DIFF
--- a/theme/pages/homepage.html
+++ b/theme/pages/homepage.html
@@ -10,13 +10,13 @@
 {% else %}
     <h2>Installation</h2>
     <h3>Using Composer</h3>
-    <pre><code class="language-bash">$ composer require laminas/{{ config.site_name }}</code></pre>
+    <pre><code class="language-bash">$ composer require {{ config.repo_url|replace('https://github.com/', '') }}</code></pre>
 {% endif %}
 
 <h2>Support</h2>
 <ul>
-    <li>Issues: <a href="https://github.com/laminas/{{ config.site_name }}/issues/">github.com/laminas/{{ config.site_name }}/issues</a></li>
-    <li>Source: <a href="https://github.com/laminas/{{ config.site_name }}/">github.com/laminas/{{ config.site_name }}</a></li>
+    <li>Issues: <a href="{{ config.repo_url }}/issues">{{ config.repo_url|replace('https://', '') }}/issues</a></li>
+    <li>Source: <a href="{{ config.repo_url }}">{{ config.repo_url|replace('https://', '') }}</a></li>
     <li>Chat: <a href="https://zendframework-slack.herokuapp.com">zendframework-slack.herokuapp.com</a></li>
     <li>Forum: <a href="https://discourse.zendframework.com/">discourse.zendframework.com</a></li>
 </ul>

--- a/theme/pages/homepage.html
+++ b/theme/pages/homepage.html
@@ -10,13 +10,13 @@
 {% else %}
     <h2>Installation</h2>
     <h3>Using Composer</h3>
-    <pre><code class="language-bash">$ composer require zendframework/{{ config.site_name }}</code></pre>
+    <pre><code class="language-bash">$ composer require laminas/{{ config.site_name }}</code></pre>
 {% endif %}
 
 <h2>Support</h2>
 <ul>
-    <li>Issues: <a href="https://github.com/zendframework/{{ config.site_name }}/issues/">github.com/zendframework/{{ config.site_name }}/issues</a></li>
-    <li>Source: <a href="https://github.com/zendframework/{{ config.site_name }}/">github.com/zendframework/{{ config.site_name }}</a></li>
+    <li>Issues: <a href="https://github.com/laminas/{{ config.site_name }}/issues/">github.com/laminas/{{ config.site_name }}/issues</a></li>
+    <li>Source: <a href="https://github.com/laminas/{{ config.site_name }}/">github.com/laminas/{{ config.site_name }}</a></li>
     <li>Chat: <a href="https://zendframework-slack.herokuapp.com">zendframework-slack.herokuapp.com</a></li>
     <li>Forum: <a href="https://discourse.zendframework.com/">discourse.zendframework.com</a></li>
 </ul>

--- a/theme/pages/installation.html
+++ b/theme/pages/installation.html
@@ -21,7 +21,7 @@
 {# Standard Installation #}
 <h2 id="standard-installation">Standard Installation</h2>
 <p>To install the library use <a href="https://getcomposer.org/">Composer</a>:</p>
-<pre><code class="language-bash">$ composer require laminas/{{ config.site_name }}</code></pre>
+<pre><code class="language-bash">$ composer require {{ config.repo_url|replace('https://github.com/', '') }}</code></pre>
 
 
 {% if config.extra.installation.config_provider_class or config.extra.installation.module_class %}
@@ -67,7 +67,7 @@
 
 <h4>Install {{ config.site_name }} and inject Configuration</h4>
 <p>To install the library use Composer:</p>
-<pre><code class="language-bash">$ composer require laminas/{{ config.site_name }}</code></pre>
+<pre><code class="language-bash">$ composer require {{ config.repo_url|replace('https://github.com/', '') }}</code></pre>
 <p>
     This will install an initial set of dependencies and it will also prompt to
     inject the component configuration.
@@ -93,7 +93,7 @@
 
 <h4>Install {{ config.site_name }}</h4>
 <p>To install the library use Composer:</p>
-<pre><code class="language-bash">$ composer require laminas/{{ config.site_name }}</code></pre>
+<pre><code class="language-bash">$ composer require {{ config.repo_url|replace('https://github.com/', '') }}</code></pre>
 
 {% if config.extra.installation.config_provider_class %}
     <h4>Configuration for a mezzio-based Application</h4>

--- a/theme/pages/installation.html
+++ b/theme/pages/installation.html
@@ -9,8 +9,8 @@
 
             {% if config.extra.installation.config_provider_class or config.extra.installation.module_class %}
             <li class="toc__entry">
-                <a href="#installation-for-zend-expressive-and-zend-mvc-application" class="toc__link">
-                    Installation for zend-expressive and zend-mvc Application
+                <a href="#installation-for-mezzio-and-laminas-mvc-application" class="toc__link">
+                    Installation for mezzio and laminas-mvc Application
                 </a>
             </li>
             {% endif %}
@@ -21,25 +21,25 @@
 {# Standard Installation #}
 <h2 id="standard-installation">Standard Installation</h2>
 <p>To install the library use <a href="https://getcomposer.org/">Composer</a>:</p>
-<pre><code class="language-bash">$ composer require zendframework/{{ config.site_name }}</code></pre>
+<pre><code class="language-bash">$ composer require laminas/{{ config.site_name }}</code></pre>
 
 
 {% if config.extra.installation.config_provider_class or config.extra.installation.module_class %}
-<h2 id="installation-for-zend-expressive-and-zend-mvc-application">
+<h2 id="installation-for-mezzio-and-laminas-mvc-application">
     Installation for
-    {% if config.extra.installation.config_provider_class %}zend-expressive{% endif %}
+    {% if config.extra.installation.config_provider_class %}mezzio{% endif %}
     {% if config.extra.installation.config_provider_class and config.extra.installation.module_class %}and{% endif %}
-    {% if config.extra.installation.module_class %}zend-mvc{% endif %}
+    {% if config.extra.installation.module_class %}laminas-mvc{% endif %}
     Application
 </h2>
 
 <h3>Installation and automated Configuration</h3>
 <p>
-    The <a href="https://docs.zendframework.com/zend-component-installer/">zend-component-installer</a>
+    The <a href="https://docs.laminas.dev/laminas-component-installer/">laminas-component-installer</a>
     is the recommended installation method when using in
-    {% if config.extra.installation.config_provider_class %}a zend-expressive-based{% endif %}
+    {% if config.extra.installation.config_provider_class %}a mezzio-based{% endif %}
     {% if config.extra.installation.config_provider_class and config.extra.installation.module_class %}or{% endif %}
-    {% if config.extra.installation.module_class %}a zend-mvc-based{% endif %} application.
+    {% if config.extra.installation.module_class %}a laminas-mvc-based{% endif %} application.
     It will automatically inject
     {% if config.extra.installation.config_provider_class %}the config-provider{% endif %}
     {% if config.extra.installation.config_provider_class and config.extra.installation.module_class %}or{% endif %}
@@ -50,34 +50,34 @@
 <blockquote>
     <h3>Installation Requirements</h3>
     <p>
-        The following descriptions depends on the zend-component-installer component,
+        The following descriptions depends on the laminas-component-installer component,
          so be sure to have it installed before getting started.
     </p>
 
     <h4>Global Installation</h4>
     <p>
-        With a <a href="https://docs.zendframework.com/zend-component-installer/#global-installation">global installation</a>
-        of zend-component-installer it can be used for all projects without a
+        With a <a href="https://docs.laminas.dev/laminas-component-installer/#global-installation">global installation</a>
+        of laminas-component-installer it can be used for all projects without a
         reinstallation.
     </p>
-    <pre><code class="language-bash">$ composer global require zendframework/zend-component-installer</code></pre>
+    <pre><code class="language-bash">$ composer global require laminas/laminas-component-installer</code></pre>
     <h4>As Development Dependency</h4>
-    <pre><code class="language-bash">$ composer require --dev zendframework/zend-component-installer</code></pre>
+    <pre><code class="language-bash">$ composer require --dev laminas/laminas-component-installer</code></pre>
 </blockquote>
 
 <h4>Install {{ config.site_name }} and inject Configuration</h4>
 <p>To install the library use Composer:</p>
-<pre><code class="language-bash">$ composer require zendframework/{{ config.site_name }}</code></pre>
+<pre><code class="language-bash">$ composer require laminas/{{ config.site_name }}</code></pre>
 <p>
     This will install an initial set of dependencies and it will also prompt to
     inject the component configuration.
 </p>
 <ul>
     {% if config.extra.installation.config_provider_class %}
-    <li>For a zend-expressive application, choose <code>config/config.php</code>.</li>
+    <li>For a mezzio application, choose <code>config/config.php</code>.</li>
     {% endif %}
     {% if config.extra.installation.module_class %}
-    <li>For a zend-mvc application, choose either <code>modules.config.php</code> or <code>application.config.php</code>.</li>
+    <li>For a laminas-mvc application, choose either <code>modules.config.php</code> or <code>application.config.php</code>.</li>
     {% endif %}
 </ul>
 <p>
@@ -93,20 +93,20 @@
 
 <h4>Install {{ config.site_name }}</h4>
 <p>To install the library use Composer:</p>
-<pre><code class="language-bash">$ composer require zendframework/{{ config.site_name }}</code></pre>
+<pre><code class="language-bash">$ composer require laminas/{{ config.site_name }}</code></pre>
 
 {% if config.extra.installation.config_provider_class %}
-    <h4>Configuration for a zend-expressive-based Application</h4>
+    <h4>Configuration for a mezzio-based Application</h4>
     <p>
         Add the configuration provider of {{ config.site_name }} to the configuration file,
         e.g. <code>config/config.php</code>:
     </p>
 
 <pre><code class="php">
-$aggregator = new Zend\ConfigAggregator\ConfigAggregator([
+$aggregator = new Laminas\ConfigAggregator\ConfigAggregator([
     // …
-    Zend\Expressive\ConfigProvider::class,
-    Zend\Expressive\Router\ConfigProvider::class,
+    Mezzio\ConfigProvider::class,
+    Mezzio\Router\ConfigProvider::class,
     {{ config.extra.installation.config_provider_class }}, // <-- Add this line
     // …
 ]);
@@ -114,7 +114,7 @@ $aggregator = new Zend\ConfigAggregator\ConfigAggregator([
 {% endif %}
 
 {% if config.extra.installation.module_class %}
-    <h4>Configuration for a zend-mvc-based Application</h4>
+    <h4>Configuration for a laminas-mvc-based Application</h4>
     <p>
         Add {{ config.site_name }} as component at the top of the configuration file for
         modules, e.g. <code>config/modules.config.php</code>:
@@ -123,9 +123,9 @@ $aggregator = new Zend\ConfigAggregator\ConfigAggregator([
 <pre><code class="php">
 return [
     '{{ config.extra.installation.module_class }}', // <-- Add this line
-    'Zend\Router',
-    'Zend\Session',
-    'Zend\Validator',
+    'Laminas\Router',
+    'Laminas\Session',
+    'Laminas\Validator',
     'Application',
 ];
 </code></pre>


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.
Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch
-->

|    Q        |   A
|------------ | ------
| Bugfix      | yes
| BC Break    | no
| New Feature | no
| RFC         | no

### Description

Theme has not been updated and it was still using zendframework references.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
