### PR TITLE
Feature: checkout repository inside our action + rename secret key

### DIFF
--- a/github-actions/docs/README.md
+++ b/github-actions/docs/README.md
@@ -51,7 +51,7 @@ empty commits, and uses an alternate base site URL.
 
 ## Environment
 
-This action requires the environment variable `$ACTIONS_DEPLOY_KEY`, which
+This action requires the environment variable `$DOCS_DEPLOY_KEY`, which
 should be a deployment key.
 
 Generate a deployment key as follows:
@@ -69,12 +69,12 @@ Under **Deploy Keys**, select the **Add Key** button, add the contents of your
 `gh-pages.pub` file, and select the "Allow Write Access" checkbox.
 
 Then go to **Secrets**, select the **Add** button, give the new secret the title
-`ACTIONS_DEPLOY_KEY`, and paste in the contents of your `gh-pages` file.
+`DOCS_DEPLOY_KEY`, and paste in the contents of your `gh-pages` file.
 
 ## Example workflow
 
 ```yaml
-name: docs
+name: docs-build
 
 on:
   push:
@@ -86,11 +86,10 @@ jobs:
   build-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - name: Build and deploy documentation
         uses: laminas/documentation-theme/github-actions/docs@master
         env:
-          ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          DOCS_DEPLOY_KEY: ${{ secrets.DOCS_DEPLOY_KEY }}
         with:
           emptyCommits: false
 ```

--- a/github-actions/docs/entrypoint.sh
+++ b/github-actions/docs/entrypoint.sh
@@ -18,17 +18,19 @@ function skip() {
     exit 0
 }
 
+# checkout the repository
+git clone git://github.com/${GITHUB_REPOSITORY}.git ${GITHUB_WORKSPACE}
+
 if [ ! -f "${GITHUB_WORKSPACE}/mkdocs.yml" ];then
     print_info "No documentation detected; skipping"
     exit 0
 fi
 
-
 # check values
 remote_repo=""
-if [ -n "${ACTIONS_DEPLOY_KEY}" ]; then
+if [ -n "${DOCS_DEPLOY_KEY}" ]; then
 
-    print_info "setup with ACTIONS_DEPLOY_KEY"
+    print_info "setup with DOCS_DEPLOY_KEY"
 
     if [ -n "${SCRIPT_MODE}" ]; then
         print_info "run as SCRIPT_MODE"
@@ -38,13 +40,12 @@ if [ -n "${ACTIONS_DEPLOY_KEY}" ]; then
     fi
     mkdir "${SSH_DIR}"
     ssh-keyscan -t rsa github.com > "${SSH_DIR}/known_hosts"
-    echo "${ACTIONS_DEPLOY_KEY}" > "${SSH_DIR}/id_rsa"
+    echo "${DOCS_DEPLOY_KEY}" > "${SSH_DIR}/id_rsa"
     chmod 400 "${SSH_DIR}/id_rsa"
 
     remote_repo="git@github.com:${GITHUB_REPOSITORY}.git"
-
 else
-    print_error "ACTIONS_DEPLOY_KEY not found"
+    print_error "DOCS_DEPLOY_KEY not found"
     exit 1
 fi
 print_info "Publishing to ${remote_repo}"

--- a/github-actions/docs/entrypoint.sh
+++ b/github-actions/docs/entrypoint.sh
@@ -32,12 +32,7 @@ if [ -n "${DOCS_DEPLOY_KEY}" ]; then
 
     print_info "setup with DOCS_DEPLOY_KEY"
 
-    if [ -n "${SCRIPT_MODE}" ]; then
-        print_info "run as SCRIPT_MODE"
-        SSH_DIR="${HOME}/.ssh"
-    else
-        SSH_DIR="/root/.ssh"
-    fi
+    SSH_DIR="/root/.ssh"
     mkdir "${SSH_DIR}"
     ssh-keyscan -t rsa github.com > "${SSH_DIR}/known_hosts"
     echo "${DOCS_DEPLOY_KEY}" > "${SSH_DIR}/id_rsa"


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.
Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Now we can use just single action in our docs-build workflow!

Renamed also secret key to `DOCS_DEPLOY_KEY` as `ACTION_DEPLOY_KEY` was very generic, as we want to be specific that this is the key to deploy the documentation.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
