### PR TITLE
Fixes wrong URLs in breadcrumb

### DIFF
--- a/theme/main.html
+++ b/theme/main.html
@@ -16,7 +16,7 @@
 
     <title>{% if page.title and page.title != 'Home' %}{{ page.title }} - {% endif %}{{ config.site_name }} - Laminas Docs</title>
 
-    <link rel="stylesheet" href="{{ ('/css/styles.css')|url }}">
+    <link rel="stylesheet" href="{{ (config.extra.base_url + '/css/styles.css')|replace('//', '/') }}">
     {%- for path in extra_css %}
         <link href="{{ path }}" rel="stylesheet">
     {%- endfor %}
@@ -57,7 +57,7 @@
             project  = "{{ config.extra.project|lower|replace(' ', '-') }}",
             siteName = '{{ config.site_name }}';
     </script>
-    <script src="{{ ('/js/scripts.js')|url }}"></script>
+    <script src="{{ (config.extra.base_url + '/js/scripts.js')|replace('//', '/') }}"></script>
     {%- for path in extra_javascript %}
         <script src="{{ path }}"></script>
     {%- endfor %}

--- a/theme/partials/breadcrumb.html
+++ b/theme/partials/breadcrumb.html
@@ -1,7 +1,8 @@
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
         {% if config.site_name != 'Documentation' %}
-            <li class="breadcrumb-item"><a href="{{ config.extra.overview_url }}">Overview</a></li>
+            <li class="breadcrumb-item"><a href="{{ config.extra.base_url }}">Overview</a></li>
+            <li class="breadcrumb-item"><a href="{{ config.extra.project_url }}">{{ config.extra.project }}</a></li>
 
             {% if page.title != 'Home' %}
                 <li class="breadcrumb-item"><a href="{{ nav.homepage.url|url }}">{{ config.site_name }}</a></li>

--- a/update_mkdocs_yml.py
+++ b/update_mkdocs_yml.py
@@ -44,6 +44,7 @@ mkdocs["theme"] = {
     }
 
 mkdocs["extra"]["repo_name"] = mkdocs["repo_url"].replace("https://github.com/", "")
+mkdocs["extra"]["base_url"] = "https://docs.laminas.dev/"
 
 if mkdocs["extra"]["project"] == "Components":
     mkdocs["extra"]["project_url"] = "https://docs.laminas.dev/components/"

--- a/update_mkdocs_yml.py
+++ b/update_mkdocs_yml.py
@@ -45,5 +45,12 @@ mkdocs["theme"] = {
 
 mkdocs["extra"]["repo_name"] = mkdocs["repo_url"].replace("https://github.com/", "")
 
+if mkdocs["extra"]["project"] == "Components":
+    mkdocs["extra"]["project_url"] = "https://docs.laminas.dev/components/"
+elif (mkdocs["extra"]["project"] == "MVC") or (mkdocs["extra"]["project"] == "Mvc"):
+    mkdocs["extra"]["project_url"] = "https://docs.laminas.dev/mvc/"
+elif mkdocs["extra"]["project"] == "Mezzio":
+    mkdocs["extra"]["project_url"] = "https://docs.mezzio.dev/"
+
 with open("mkdocs.yml", "w") as f:
     yaml.dump(mkdocs, f, default_flow_style=False)


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

With the initial build of all documentations some changes were introduced. These changes results in wrong URLs in the breadcrumb.
Additionally this pull request adds a new configuration option for a base URL which is used in the breadcrumb and for the URLs of CSS and JS.

Related to #18 

---

_The problem with configuration option `site_url` of MkDocs is *not* covered by this pull request! This will be done in a separate pull request._