### PR TITLE
Footer alignments

### DIFF
--- a/theme/partials/footer.html
+++ b/theme/partials/footer.html
@@ -9,7 +9,7 @@
         </div>
 
         <div class="row">
-            <div class="col-md-7 offset-md-2">
+            <div class="col-md-10 offset-md-2">
                 <h5>Laminas</h5>
                 <ul>
                     <li>Laminas Project <a href="https://getlaminas.org/">The new foundation for the community-supported, open source continuation of Zend Framework</a></li>
@@ -21,49 +21,53 @@
         </div>
 
         <div class="row">
+            <div class="col-md-10 offset-md-2"> 
+                <div class="row">
 
-            {# Support links #}
-            <div class="col-md-4 offset-md-2">
-                <h4 class="footer__headline">Support</h4>
-                <ul class="support__list">
-                    <li class="support__list-item">
-                        <a href="https://discourse.laminas.dev" class="support__link" title="Forum"><i class="fa fa-comments"></i></a>
-                    </li>
-                    <li class="support__list-item">
-                        <a href="https://laminas.dev/chat" class="support__link" title="Chat"><i class="fa fa-slack"></i></a>
-                    </li>
-                    <li class="support__list-item">
-                        <a href="https://github.com/laminas" class="support__link" title="Github"><i class="fa fa-github"></i></a>
-                    </li>
-                    <li class="support__list-item">
-                        <a href="https://twitter.com/getlaminas" class="support__link" title="Twitter"><i class="fa fa-twitter"></i></a>
-                    </li>
-                    <li class="support__list-item">
-                        <a href="https://getlaminas.org/blog/feed-rss.xml" class="support__link" title="Blog feed"><i class="fa fa-rss"></i></a>
-                    </li>
-                    <li class="support__list-item">
-                        <a href="https://getlaminas.org/security/feed" class="support__link" title="Security feed"><i class="fa fa-rss-square"></i></a>
-                    </li>
-                </ul>
-            </div>
+                    {# Support links #}
+                    <div class="col-md-4">
+                        <h4 class="footer__headline">Support</h4>
+                        <ul class="support__list">
+                            <li class="support__list-item">
+                                <a href="https://discourse.laminas.dev" class="support__link" title="Forum"><i class="fa fa-comments"></i></a>
+                            </li>
+                            <li class="support__list-item">
+                                <a href="https://laminas.dev/chat" class="support__link" title="Chat"><i class="fa fa-slack"></i></a>
+                            </li>
+                            <li class="support__list-item">
+                                <a href="https://github.com/laminas" class="support__link" title="Github"><i class="fa fa-github"></i></a>
+                            </li>
+                            <li class="support__list-item">
+                                <a href="https://twitter.com/getlaminas" class="support__link" title="Twitter"><i class="fa fa-twitter"></i></a>
+                            </li>
+                            <li class="support__list-item">
+                                <a href="https://getlaminas.org/blog/feed-rss.xml" class="support__link" title="Blog feed"><i class="fa fa-rss"></i></a>
+                            </li>
+                            <li class="support__list-item">
+                                <a href="https://getlaminas.org/security/feed" class="support__link" title="Security feed"><i class="fa fa-rss-square"></i></a>
+                            </li>
+                        </ul>
+                    </div>
 
-            {# License #}
-            <div class="col-md-3">
-                <h4 class="footer__headline">License</h4>
-                <p>
-                    Code licensed under <a
-                        href="{{ config.repo_url }}blob/master/LICENSE.md">BSD 3-Clause</a>.
-                </p>
-            </div>
+                    {# License #}
+                    <div class="col-md-4">
+                        <h4 class="footer__headline">License</h4>
+                        <p>
+                            Code licensed under <a
+                                href="{{ config.repo_url }}blob/master/LICENSE.md">BSD 3-Clause</a>.
+                        </p>
+                    </div>
 
-            {# Copyright #}
-            <div class="col-md-3">
-                <h4 class="footer__headline">Copyright</h4>
-                <p>
-                    <!--Built with love by the Laminas team with the help of our
-                    <a href="{{ config.repo_url }}graphs/contributors">contributors</a>.<br>-->
-                    &copy; 2019-{{ build_date_utc.strftime('%Y') }} by <a href="https://getlaminas.org/">The Laminas Project</a>.
-                </p>
+                    {# Copyright #}
+                    <div class="col-md-4">
+                        <h4 class="footer__headline">Copyright</h4>
+                        <p>
+                            <!--Built with love by the Laminas team with the help of our
+                            <a href="{{ config.repo_url }}graphs/contributors">contributors</a>.<br>-->
+                            &copy; 2019-{{ build_date_utc.strftime('%Y') }} by <a href="https://getlaminas.org/">The Laminas Project</a>.
+                        </p>
+                    </div>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
In footer we have three columns:
Support | License | Copyright

Now Support is the widest and because of that Copyright is in two lines.
When columns in footer are equal all fits perfectly fine :)

after update:

![image](https://user-images.githubusercontent.com/7423207/72631889-05c0ae00-394d-11ea-999b-36ca6840ba6e.png)

vs current version:

![image](https://user-images.githubusercontent.com/7423207/72632533-613f6b80-394e-11ea-89c9-722f24cba8ac.png)

