### PR TITLE
Adds option for Composer installation command for dev

### DIFF
--- a/theme/pages/homepage.html
+++ b/theme/pages/homepage.html
@@ -10,7 +10,7 @@
 {% else %}
     <h2>Installation</h2>
     <h3>Using Composer</h3>
-    <pre><code class="language-bash">$ composer require {{ config.extra.repo_name }}</code></pre>
+    <pre><code class="language-bash">$ composer require {% if config.extra.installation.composer_dev %}--dev {% endif %}{{ config.extra.repo_name }}</code></pre>
 {% endif %}
 
 <h2>Support</h2>

--- a/theme/pages/installation.html
+++ b/theme/pages/installation.html
@@ -23,7 +23,7 @@
 {# Standard Installation #}
 <h2 id="standard-installation">Standard Installation</h2>
 <p>To install the library use <a href="https://getcomposer.org/">Composer</a>:</p>
-<pre><code class="language-bash">$ composer require {{ config.extra.repo_name }}</code></pre>
+<pre><code class="language-bash">$ composer require {% if config.extra.installation.composer_dev %}--dev {% endif %}{{ config.extra.repo_name }}</code></pre>
 
 
 {% if config.extra.installation.config_provider_class or config.extra.installation.module_class %}
@@ -69,7 +69,7 @@
 
 <h4>Install {{ config.site_name }} and inject Configuration</h4>
 <p>To install the library use Composer:</p>
-<pre><code class="language-bash">$ composer require {{ config.extra.repo_name }}</code></pre>
+<pre><code class="language-bash">$ composer require {% if config.extra.installation.composer_dev %}--dev {% endif %}{{ config.extra.repo_name }}</code></pre>
 <p>
     This will install an initial set of dependencies and it will also prompt to
     inject the component configuration.
@@ -95,7 +95,7 @@
 
 <h4>Install {{ config.site_name }}</h4>
 <p>To install the library use Composer:</p>
-<pre><code class="language-bash">$ composer require {{ config.extra.repo_name }}</code></pre>
+<pre><code class="language-bash">$ composer require {% if config.extra.installation.composer_dev %}--dev {% endif %}{{ config.extra.repo_name }}</code></pre>
 
 {% if config.extra.installation.config_provider_class %}
     <h4>Manual configuration for a Mezzio-based application</h4>


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes

The option is needed for components like laminas-cli or laminas-coding-standard.

```yml
extra:
    project: Components
    installation:
        composer_dev: true
```

The documentation for this and all other configuration options will be added as guideline to documentation repository.