### PR TITLE
Post-process search items to escape HTML entities

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -78,3 +78,7 @@ php ${SCRIPT_PATH}/table_responsive.php ${DOC_DIR}
 # Fix pipes in tables
 echo "Fixing pipes in tables"
 php ${SCRIPT_PATH}/table_fix_pipes.php ${DOC_DIR}
+
+# Escape tags in search data
+echo "Escaping tags in search data"
+php ${SCRIPT_PATH}/escape_search_data.php ${DOC_DIR}/html/search/search_index.json

--- a/escape_search_data.php
+++ b/escape_search_data.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Escapes tags found in search data
+ */
+
+if (! isset($argv[1])) {
+    echo "[FAILED] No search index file provided\n";
+    exit(1);
+}
+
+$searchIndexFile = $argv[1];
+
+if (! file_exists($searchIndexFile)) {
+    printf("[FAILED] Search index file '%s' does not exist\n", $searchIndexFile);
+    exit(1);
+}
+
+$json = file_get_contents($searchIndexFile);
+
+try {
+    $index = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+} catch (Throwable $e) {
+    printf("[FAILED] Could not parse file '%s': %s\n", $searchIndexFile, $e->getMessage());
+    exit(1);
+}
+
+if (! isset($index['docs'])) {
+    printf("[FAILED] Invalid search index structure in file '%s'\n", $searchIndexFile);
+    exit(1);
+}
+
+$index['docs'] = array_map(function ($item) {
+    $item['text'] = htmlspecialchars($item['text'], ENT_HTML5 | ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8', false);
+    return $item;
+}, $index['docs']);
+
+$json = json_encode($index, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+file_put_contents($searchIndexFile, $json);


### PR DESCRIPTION
Fixes issues where contents of `<pre>` sections contained HTML elements, which could lead to HTML tags being emitted when displaying search results.

Fixes #46