### PR TITLE
Allow usage with repositories using release branches

### DIFF
--- a/github-actions/docs/Dockerfile
+++ b/github-actions/docs/Dockerfile
@@ -9,6 +9,7 @@ RUN apk upgrade --no-cache \
     python3 \
     python3-dev \
     php7 \
+    php7-curl \
     php7-fileinfo \
     php7-json \
   && pip3 install --no-cache-dir --upgrade pip \

--- a/github-actions/docs/README.md
+++ b/github-actions/docs/README.md
@@ -79,7 +79,8 @@ name: docs-build
 on:
   push:
     branches:
-      - '*'
+      - 'master'
+      - '*.x'
     paths:
       - 'docs/book/**'
       - 'mkdocs.yml'

--- a/github-actions/docs/README.md
+++ b/github-actions/docs/README.md
@@ -79,7 +79,7 @@ name: docs-build
 on:
   push:
     branches:
-      - master
+      - '*'
   repository_dispatch:
     types: docs-build
 

--- a/github-actions/docs/README.md
+++ b/github-actions/docs/README.md
@@ -80,6 +80,10 @@ on:
   push:
     branches:
       - '*'
+    paths:
+      - 'docs/book/**'
+      - 'mkdocs.yml'
+      - 'doc/book/**'
   repository_dispatch:
     types: docs-build
 

--- a/github-actions/docs/determine_if_we_need_to_build.php
+++ b/github-actions/docs/determine_if_we_need_to_build.php
@@ -59,7 +59,7 @@ if (! preg_match('/^\d+\.\d+\.x$/', $ref)) {
 $compareRefNames = function ($a, $b) {
     $a = preg_replace('/\.x$/', '.0', $a);
     $b = preg_replace('/\.x$/', '.0', $b);
-    return $a <=> $b;
+    return version_compare($a, $b);
 };
 
 $branches = executeApiCall($repo, 'branches', $token);

--- a/github-actions/docs/determine_if_we_need_to_build.php
+++ b/github-actions/docs/determine_if_we_need_to_build.php
@@ -2,10 +2,16 @@
 
 declare(strict_types=1);
 
+/*
+ * DECLARATIONS
+ */
 $ref   = getenv('GITHUB_REF');
 $repo  = getenv('GITHUB_REPOSITORY');
 $token = getenv('GITHUB_TOKEN');
 
+/*
+ * FUNCTIONS
+ */
 function buildDocs() {
     echo "TRUE";
     exit(0);
@@ -14,6 +20,13 @@ function buildDocs() {
 function skipDocs() {
     echo "FALSE";
     exit(0);
+}
+
+function compareRefNames(string $a, string $b): int
+{
+    $a = preg_replace('/\.x$/', '.0', $a);
+    $b = preg_replace('/\.x$/', '.0', $b);
+    return version_compare($a, $b);
 }
 
 /**
@@ -33,7 +46,7 @@ function executeApiCall(string $repo, string $resource, string $token): array
     $payload  = array_map(static function (string $ref): string {
         return $ref['name'];
     }, $payload);
-    usort($payload, $compareRefNames);
+    usort($payload, 'compareRefNames');
     return $payload;
 }
 
@@ -44,39 +57,27 @@ function extractMajorMinorVersion(string $version): string
     return $matches['release'] ?? $version;
 }
 
+/*
+ * MAIN
+ */
+
+// Assume that release branches are not in use if we detect a push to master
 if ('master' === $ref) {
-    // Assume that release branches are not in use if we detect a push to master
     buildDocs();
     exit(0); // redundant; placed here to note that buildDocs exits
 }
 
+// Not a release branch
 if (! preg_match('/^\d+\.\d+\.x$/', $ref)) {
-    // Not a release branch
     skipDocs();
     exit(0); // redundant; placed here to note that skipDocs exits
 }
 
-$compareRefNames = function ($a, $b) {
-    $a = preg_replace('/\.x$/', '.0', $a);
-    $b = preg_replace('/\.x$/', '.0', $b);
-    return version_compare($a, $b);
-};
-
-$branches = executeApiCall($repo, 'branches', $token);
-$branches = array_filter($branches, function ($branch) {
-    return (bool) preg_match('/^\d+\.\d+\.x$/', $branch);
-});
-$mostRecent = array_pop($branches);
-if ($mostRecent === $ref) {
-    buildDocs();
-    exit(0); // redundant; placed here to note that buildDocs exits
-}
-
-$tags = executeApiCall($repo, 'tags', $token);
-$committedReleaseVersion = extractMajorMinorVersion($ref);
+// Compare release branch name against latest tag name (by semver)
+$tags                     = executeApiCall($repo, 'tags', $token);
+$committedReleaseVersion  = extractMajorMinorVersion($ref);
 $mostRecentReleaseVersion = extractMajorMinorVersion(array_pop($tags));
-if ($committedReleaseVersion !== $mostRecentReleaseVersion) {
-    skipDocs();
-    exit(0); // redundant; placed here to note that skipDocs exits
-}
-buildDocs();
+
+$committedReleaseVersion === $mostRecentReleaseVersion
+    ? buildDocs()
+    : skipDocs();

--- a/github-actions/docs/determine_if_we_need_to_build.php
+++ b/github-actions/docs/determine_if_we_need_to_build.php
@@ -52,8 +52,8 @@ if ('master' === $ref) {
 
 if (! preg_match('/^\d+\.\d+\.x$/', $ref)) {
     // Not a release branch
-    skipDocs(); // redundant; placed here to note that skipDocs exits
-    exit(0);
+    skipDocs();
+    exit(0); // redundant; placed here to note that skipDocs exits
 }
 
 $compareRefNames = function ($a, $b) {
@@ -68,15 +68,15 @@ $branches = array_filter($branches, function ($branch) {
 });
 $mostRecent = array_pop($branches);
 if ($mostRecent === $ref) {
-    buildDocs(); // redundant; placed here to note that buildDocs exits
-    exit(0);
+    buildDocs();
+    exit(0); // redundant; placed here to note that buildDocs exits
 }
 
 $tags = executeApiCall($repo, 'tags', $token);
 $committedReleaseVersion = extractMajorMinorVersion($ref);
 $mostRecentReleaseVersion = extractMajorMinorVersion(array_pop($tags));
 if ($committedReleaseVersion !== $mostRecentReleaseVersion) {
-    skipDocs(); // redundant; placed here to note that skipDocs exits
-    exit(0);
+    skipDocs();
+    exit(0); // redundant; placed here to note that skipDocs exits
 }
 buildDocs();

--- a/github-actions/docs/determine_if_we_need_to_build.php
+++ b/github-actions/docs/determine_if_we_need_to_build.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+$ref   = getenv('GITHUB_REF');
+$repo  = getenv('GITHUB_REPOSITORY');
+$token = getenv('GITHUB_TOKEN');
+
+function buildDocs() {
+    echo "TRUE";
+    exit(0);
+}
+
+function skipDocs() {
+    echo "FALSE";
+    exit(0);
+}
+
+/**
+ * @return string[]
+ */
+function executeApiCall(string $repo, string $resource, string $token): array
+{
+    curl_init('https://api.github.com/repos/' . $repo . '/' . $resource);
+    curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($curl, CURLOPT_HTTPHEADER, [
+        'Authorization: bearer ' . $token,
+        'User-Agent: laminas/docs',
+        'Accept: application/vnd.github+json',
+    ]);
+    $response = curl_exec($curl);
+    $payload  = json_decode($response, true);
+    $payload  = array_map(static function (string $ref): string {
+        return $ref['name'];
+    }, $payload);
+    usort($payload, $compareRefNames);
+    return $payload;
+}
+
+function extractMajorMinorVersion(string $version): string
+{
+    $matches = [];
+    preg_match('/^(?P<release>\d+\.\d+)\./', $version, $matches);
+    return $matches['release'] ?? $version;
+}
+
+if ('master' === $ref) {
+    // Assume that release branches are not in use if we detect a push to master
+    buildDocs();
+    exit(0); // redundant; placed here to note that buildDocs exits
+}
+
+if (! preg_match('/^\d+\.\d+\.x$/', $ref)) {
+    // Not a release branch
+    skipDocs(); // redundant; placed here to note that skipDocs exits
+    exit(0);
+}
+
+$compareRefNames = function ($a, $b) {
+    $a = preg_replace('/\.x$/', '.0', $a);
+    $b = preg_replace('/\.x$/', '.0', $b);
+    return $a <=> $b;
+};
+
+$branches = executeApiCall($repo, 'branches', $token);
+$branches = array_filter($branches, function ($branch) {
+    return (bool) preg_match('/^\d+\.\d+\.x$/', $branch);
+});
+$mostRecent = array_pop($branches);
+if ($mostRecent === $ref) {
+    buildDocs(); // redundant; placed here to note that buildDocs exits
+    exit(0);
+}
+
+$tags = executeApiCall($repo, 'tags', $token);
+$committedReleaseVersion = extractMajorMinorVersion($ref);
+$mostRecentReleaseVersion = extractMajorMinorVersion(array_pop($tags));
+if ($committedReleaseVersion !== $mostRecentReleaseVersion) {
+    skipDocs(); // redundant; placed here to note that skipDocs exits
+    exit(0);
+}
+buildDocs();

--- a/github-actions/docs/entrypoint.sh
+++ b/github-actions/docs/entrypoint.sh
@@ -5,6 +5,10 @@
 
 set -e
 
+export TOP_PID=$$
+trap "exit 0" TERM
+trap "exit 1" KILL
+
 function print_error() {
     echo -e "\e[31mERROR: ${1}\e[m"
 }
@@ -15,7 +19,7 @@ function print_info() {
 
 function skip() {
     print_info "No changes detected, skipping deployment"
-    exit 0
+    kill -s TERM $TOP_PID
 }
 
 # checkout the repository
@@ -23,7 +27,7 @@ git clone git://github.com/${GITHUB_REPOSITORY}.git ${GITHUB_WORKSPACE}
 
 if [ ! -f "${GITHUB_WORKSPACE}/mkdocs.yml" ];then
     print_info "No documentation detected; skipping"
-    exit 0
+    kill -s TERM $TOP_PID
 fi
 
 # check values
@@ -41,7 +45,7 @@ if [ -n "${DOCS_DEPLOY_KEY}" ]; then
     remote_repo="git@github.com:${GITHUB_REPOSITORY}.git"
 else
     print_error "DOCS_DEPLOY_KEY not found"
-    exit 1
+    kill -s KILL $TOP_PID
 fi
 print_info "Publishing to ${remote_repo}"
 

--- a/github-actions/docs/entrypoint.sh
+++ b/github-actions/docs/entrypoint.sh
@@ -18,9 +18,15 @@ function print_info() {
 }
 
 function skip() {
-    print_info "No changes detected, skipping deployment"
+    print_info "Skipping documentation build"
     kill -s TERM $TOP_PID
 }
+
+DO_WE_BUILD=$(php determine_if_we_need_to_build.php)
+if [[ "${DO_WE_BUILD}" != "TRUE" ]]; then
+    print_info "Not a branch, or not the most recent release branch with a tag; skipping"
+    kill -s TERM $TOP_PID
+fi
 
 # checkout the repository
 git clone git://github.com/${GITHUB_REPOSITORY}.git ${GITHUB_WORKSPACE}


### PR DESCRIPTION
This patch adds a script at the start of the entrypoint that detects whether or not we should build docs for the given push, using the following rules:

- If the branch is "master", BUILD.
- If the branch name does not match `\d+\.\d+\.x`, we DO NOT BUILD.
- If the latest tag (per semver) matches the major/minor version of the branch, WE BUILD.
- Otherwise, we DO NOT BUILD.

The script is fairly primitive; I didn't want to bring in any extra deps (e.g., via Composer), but is based on work I've done locally to try out approaches. I'm willing to add assertions as necessary; mainly wanting some initial feedback.