### PR TITLE
Build only latest tags

### DIFF
--- a/github-actions/docs/Dockerfile
+++ b/github-actions/docs/Dockerfile
@@ -9,6 +9,7 @@ RUN apk upgrade --no-cache \
     python3 \
     python3-dev \
     php7 \
+    php7-curl \
     php7-fileinfo \
     php7-json \
   && pip3 install --no-cache-dir --upgrade pip \
@@ -23,4 +24,5 @@ RUN pip install nltk==3.4.5
 RUN pip install mkdocs pyaml pymdown-extensions
 
 COPY entrypoint.sh /usr/bin/entrypoint.sh
+COPY do-we-build-and-if-so-what.php /usr/bin/do-we-build-and-if-so-what.php
 ENTRYPOINT [ "/usr/bin/entrypoint.sh" ]

--- a/github-actions/docs/README.md
+++ b/github-actions/docs/README.md
@@ -77,6 +77,34 @@ Then go to **Secrets**, select the **Add** button, give the new secret the title
 name: docs-build
 
 on:
+  release:
+    types: [published]
+  repository_dispatch:
+    types: docs-build
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build and deploy documentation
+        uses: laminas/documentation-theme/github-actions/docs@master
+        env:
+          DOCS_DEPLOY_KEY: ${{ secrets.DOCS_DEPLOY_KEY }}
+        with:
+          emptyCommits: false
+```
+
+### Legacy workflow
+
+If your repository has not yet updated to use release branches and/or
+[automatic-releases](https://github.com/laminas/automatic-releases], and you are
+still using the "master" branch to reflect current stable, you may also use the
+following workflow:
+
+```yaml
+name: docs-build
+
+on:
   push:
     branches:
       - master

--- a/github-actions/docs/do-we-build-and-if-so-what.php
+++ b/github-actions/docs/do-we-build-and-if-so-what.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * DECLARATIONS
+ */
+$ref   = getenv('GITHUB_REF');
+$repo  = getenv('GITHUB_REPOSITORY');
+$token = getenv('GITHUB_TOKEN');
+
+/*
+ * FUNCTIONS
+ */
+function buildDocs(string $ref) {
+    echo $ref;
+    exit(0);
+}
+
+function skipDocs() {
+    echo "FALSE";
+    exit(0);
+}
+
+/**
+ * @return string[]
+ */
+function executeApiCall(string $repo, string $resource, string $token): array
+{
+    curl_init('https://api.github.com/repos/' . $repo . '/' . $resource);
+    curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($curl, CURLOPT_HTTPHEADER, [
+        'Authorization: bearer ' . $token,
+        'User-Agent: laminas/docs',
+        'Accept: application/vnd.github+json',
+    ]);
+    $response = curl_exec($curl);
+    $payload  = json_decode($response, true);
+    $payload  = array_map(static function (string $ref): string {
+        return $ref['name'];
+    }, $payload);
+    usort($payload, 'version_compare');
+    return $payload;
+}
+
+/*
+ * MAIN
+ */
+
+// Push to master branch (legacy):
+if ($ref === 'master') {
+    buildDocs('master');
+    exit(0); // redundant; placed here to note that buildDocs exits
+}
+
+$tags = executeApiCall($repo, 'releases', $token);
+$latestStableRelease = array_pop($tags);
+
+// Manual build request (matches sha-1):
+if (preg_match('/^[a-f0-9]{40}$/i', $ref)) {
+    buildDocs($latestStableRelease);
+    exit(0); // redundant; placed here to note that buildDocs exits
+}
+
+// Not a stable release:
+if (! preg_match('/^\d+\.\d+\.\d+(?:(p|pl|patch)\d+)?$/', $ref)) {
+    skipDocs();
+    exit(0); // redundant; placed here to note that skipDocs exits
+}
+
+// Is this the latest release according to semver?
+$ref === $latestStableRelease
+    ? buildDocs($ref)
+    : skipDocs();

--- a/github-actions/docs/entrypoint.sh
+++ b/github-actions/docs/entrypoint.sh
@@ -5,6 +5,10 @@
 
 set -e
 
+export TOP_PID=$$
+trap "exit 0" TERM
+trap "exit 1" KILL
+
 function print_error() {
     echo -e "\e[31mERROR: ${1}\e[m"
 }
@@ -15,7 +19,7 @@ function print_info() {
 
 function skip() {
     print_info "No changes detected, skipping deployment"
-    exit 0
+    kill -s TERM $TOP_PID
 }
 
 # checkout the repository
@@ -23,7 +27,7 @@ git clone git://github.com/${GITHUB_REPOSITORY}.git ${GITHUB_WORKSPACE}
 
 if [ ! -f "${GITHUB_WORKSPACE}/mkdocs.yml" ];then
     print_info "No documentation detected; skipping"
-    exit 0
+    kill -s TERM $TOP_PID
 fi
 
 # check values
@@ -41,7 +45,7 @@ if [ -n "${DOCS_DEPLOY_KEY}" ]; then
     remote_repo="git@github.com:${GITHUB_REPOSITORY}.git"
 else
     print_error "DOCS_DEPLOY_KEY not found"
-    exit 1
+    kill -s KILL $TOP_PID
 fi
 print_info "Publishing to ${remote_repo}"
 


### PR DESCRIPTION
Alternative to #49.

First, this patch modifies when the workflow is triggered:

- It can trigger for pushes to the master branch (existing/legacy behavior).
- It can trigger on release publication (new behavior).
- It can trigger for a manual dispatch (existing behavior, but modified as described below).

For all types, the entrypoint now calls on a new PHP script, `do-we-build-and-if-so-what.php`, at the beginning of execution. This script does the following:

- If this is a `push` event against the `master` branch, we build docs.
- If this is none of `push`, `release`, or `repository_dispatch` events, we skip docs.
- It pulls a list of releases, filtering out non-stable releases and them via semver in ASC order, and then detects the latest stable release.
- If this is a `repository_dispatch` event, we build docs for the latest stable release tag.
- If the release is for a non-stable version, we skip docs.
- If the release is earlier than the latest stable version, we skip docs.
- At this point, the release is the same as the latest stable version, so we build docs.

The script communicates with the entrypoint via STDOUT, and we use the string "FALSE" to indicate it should terminate early without building; anything else is considered a reference we can checkout for purposes of building docs.

This approach should allow the action to continue to work on existing repositories, and then allow updating those that are using release branches to adopt the release-based workflow.

Additionally, it updates the README to indicate the workflow should be done for releases and manual builds, and details the legacy workflow as "legacy".