### PR TITLE
Updates MkDocs config to allow attributes for code examples

### DIFF
--- a/update_mkdocs_yml.py
+++ b/update_mkdocs_yml.py
@@ -22,7 +22,16 @@ mkdocs["markdown_extensions"] = [
                 "use_pygments": False
             }
         },
-        "pymdownx.superfences:",
+        "attr_list:",
+        {
+            "pymdownx.superfences": {
+                "custom_fences": {
+                    "name": "php",
+                    "class": "language-php",
+                    "format": "!!python/name:pymdownx.superfences.fence_code_format"
+                }
+            }
+        },
         "pymdownx.tabbed:",
         {
             "toc": {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Enhancement        | yes

This allows:

``````
```{.php data-line=8-9,12-17}
namespace Album;

use Laminas\ServiceManager\Factory\InvokableFactory;

return [
    'controllers' => [
        'factories' => [
            // Add this line
            Controller\AlbumController::class => Controller\AlbumControllerFactory::class,
        ],
    ],
    // Add the following array
    'input_filters' => [
        'factories => [
            InputFilter\QueryInputFilter::class => InvokableFactory::class,
        ],
    ],
    // …
];
```
``````

Reference:

* https://facelessuser.github.io/pymdown-extensions/extensions/superfences/#injecting-classes-ids-and-
attributes
* https://facelessuser.github.io/pymdown-extensions/extensions/superfences/#formatters
