### PR TITLE
Updates MkDocs config to use dot notation for Markdown extension

### DIFF
--- a/update_mkdocs_yml.py
+++ b/update_mkdocs_yml.py
@@ -22,7 +22,7 @@ mkdocs["markdown_extensions"] = [
                 "use_pygments": False
             }
         },
-        "attr_list:",
+        "markdown.extensions.attr_list:",
         {
             "pymdownx.superfences": {
                 "custom_fences": {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

Reference: https://python-markdown.github.io/extensions/#officially-supported-extensions