### PR TITLE
Fix invalid markdown_extensions configuration

### DIFF
--- a/update_mkdocs_yml.py
+++ b/update_mkdocs_yml.py
@@ -22,9 +22,9 @@ mkdocs["markdown_extensions"] = [
                 "use_pygments": False
             }
         },
-        "markdown.extensions.attr_list:",
-        "pymdownx.superfences":,
-        "pymdownx.tabbed:",
+        "markdown.extensions.attr_list",
+        "pymdownx.superfences",
+        "pymdownx.tabbed",
         {
             "toc": {
                 "toc_depth": 2


### PR DESCRIPTION
Several items in the list incorrectly had ":" appended in their strings, and at least one had `:` appended _after_ the string, but _before_ the comma delimiter.