### PR TITLE
Adds support for related documentations to the sidebar

### DIFF
--- a/theme/main.html
+++ b/theme/main.html
@@ -48,6 +48,7 @@
                 {% if config.site_name != 'Documentation' %}
                     {% include "partials/component-selector.html" %}
                     {% include "partials/subnavigation.html" %}
+                    {% include "partials/related-documentations.html" %}
                 {% endif %}
             </div>
         </div>

--- a/theme/partials/related-documentations.html
+++ b/theme/partials/related-documentations.html
@@ -1,0 +1,14 @@
+{% if config.extra.related_documentations != Undefined and config.extra.related_documentations.headline != Undefined and config.extra.related_documentations.links != Undefined %}
+    <div class="subnavigation hidden-print">
+        <h4 class="subnavigation__title">{{ config.extra.related_documentations.headline|e }}</h4>
+        <ul class="subnavigation__list">
+            {% for link in config.extra.related_documentations.links %}
+                <li class="subnavigation__list-item">
+                    {% for label, href in link.items() %}
+                        <a href="{{ href }}" class="subnavigation__link">{{ label|e }}</a>
+                    {% endfor %}
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
+{% endif %}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes

Related to https://github.com/laminas/documentation/issues/17

## Description

Links can be added via `mkdocs.yml`.

### Example

```yaml
extra:
    project: Components
    installation:
        config_provider_class: 'Laminas\I18n\ConfigProvider'
        module_class: 'Laminas\I18n\Module'
    related_documentations:
        headline: Related Components
        links:
            - 'Translation Resources': https://docs.laminas.dev/laminas-i18n-resources/
```

### Preview

![Bildschirmfoto 2021-01-07 um 11 02 31](https://user-images.githubusercontent.com/103362/103879299-f4316280-50d7-11eb-970c-d3541d98f2fe.png)

## Documentation

The description for the use of this function will be added to the Documentation Writer's Manual.
