### PR TITLE
Adds extenstion md_in_html to update script for MkDocs config

### DIFF
--- a/update_mkdocs_yml.py
+++ b/update_mkdocs_yml.py
@@ -23,6 +23,7 @@ mkdocs["markdown_extensions"] = [
             }
         },
         "markdown.extensions.attr_list",
+        "markdown.extensions.md_in_html",
         "pymdownx.superfences",
         "pymdownx.tabbed",
         {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Enhancement   | yes

### Description

To ensure that the Markdown syntax also works within the HTML elements, another extension is needed. For example in a [details disclosure element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details).

See: https://python-markdown.github.io/extensions/md_in_html/
