### PR TITLE
Adds condition to output individual content of the installation page file

### DIFF
--- a/theme/partials/content.html
+++ b/theme/partials/content.html
@@ -15,6 +15,10 @@
     {% include "pages/homepage.html" %}
 {% elif config.extra.installation and page.title == 'Installation' %}
     {% include "pages/installation.html" %}
+
+    {% if page.meta.show_file_content %}
+        {{ page.content }}
+    {% endif %}
 {% else %}
 
     {# Skip version numbers like v1, v2, v3 #}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes

## Usage

Add the following [metadata](https://www.mkdocs.org/user-guide/writing-your-docs/#meta-data) to the Markdown file and the content will be added at the end of the installation page:

```markdown
---
show_file_content: true
---

# Additional Content for Installation Page
```