### PR TITLE
Prefer a DEPLOY_TOKEN over DOCS_DEPLOY_KEY

### DIFF
--- a/github-actions/docs/entrypoint.sh
+++ b/github-actions/docs/entrypoint.sh
@@ -7,6 +7,7 @@ set -e
 
 export TOP_PID=$$
 trap "exit 0" TERM
+# shellcheck disable=SC2173
 trap "exit 1" KILL
 
 function print_error() {
@@ -22,15 +23,38 @@ function skip() {
     kill -s TERM $TOP_PID
 }
 
-export WHAT_DO_WE_BUILD=$(php /usr/bin/do-we-build-and-if-so-what.php)
+function remote_repo_setup() {
+    local -n RESULT=$1
+    local DEPLOY_TOKEN=$2
+    RESULT="https://${DEPLOY_TOKEN}:x-oauth-basic@github.com/${GITHUB_REPOSITORY}.git"
+}
+
+function remote_repo_setup_legacy() {
+    local -n RESULT=$1
+    local DEPLOY_KEY=$2
+
+    print_info "setup with DOCS_DEPLOY_KEY"
+
+    SSH_DIR="/root/.ssh"
+    mkdir "${SSH_DIR}"
+    ssh-keyscan -t rsa github.com > "${SSH_DIR}/known_hosts"
+    echo "${DEPLOY_KEY}" > "${SSH_DIR}/id_rsa"
+    chmod 400 "${SSH_DIR}/id_rsa"
+
+    # shellcheck disable=SC2034
+    RESULT="git@github.com:${GITHUB_REPOSITORY}.git"
+}
+
+WHAT_DO_WE_BUILD=$(php /usr/bin/do-we-build-and-if-so-what.php)
+export WHAT_DO_WE_BUILD
 if [[ "${WHAT_DO_WE_BUILD}" == "FALSE" ]]; then
     print_info "Not the most recent tag, or not a manual build request; skipping"
     kill -s TERM $TOP_PID
 fi
 
 # checkout the repository at the given reference
-git clone git://github.com/${GITHUB_REPOSITORY}.git ${GITHUB_WORKSPACE}
-(cd ${GITHUB_WORKSPACE} && git checkout ${WHAT_DO_WE_BUILD})
+git clone "git://github.com/${GITHUB_REPOSITORY}.git ${GITHUB_WORKSPACE}"
+(cd "${GITHUB_WORKSPACE}" && git checkout "${WHAT_DO_WE_BUILD}")
 
 if [ ! -f "${GITHUB_WORKSPACE}/mkdocs.yml" ];then
     print_info "No documentation detected; skipping"
@@ -39,22 +63,17 @@ fi
 
 # check values
 remote_repo=""
-if [ -n "${DOCS_DEPLOY_KEY}" ]; then
-
-    print_info "setup with DOCS_DEPLOY_KEY"
-
-    SSH_DIR="/root/.ssh"
-    mkdir "${SSH_DIR}"
-    ssh-keyscan -t rsa github.com > "${SSH_DIR}/known_hosts"
-    echo "${DOCS_DEPLOY_KEY}" > "${SSH_DIR}/id_rsa"
-    chmod 400 "${SSH_DIR}/id_rsa"
-
-    remote_repo="git@github.com:${GITHUB_REPOSITORY}.git"
+if [ -n "${DEPLOY_TOKEN}" ]; then
+    remote_repo_setup remote_repo "${DEPLOY_TOKEN}"
 else
-    print_error "DOCS_DEPLOY_KEY not found"
-    kill -s KILL $TOP_PID
+    if [ -n "${DOCS_DEPLOY_KEY}" ]; then
+        remote_repo_setup_legacy remote_repo "${DOCS_DEPLOY_KEY}"
+    else
+        print_error "Neither DEPLOY_TOKEN nor DOCS_DEPLOY_KEY found; please provide one or the other in your workflow env"
+        kill -s KILL $TOP_PID
+    fi
 fi
-print_info "Publishing to ${remote_repo}"
+print_info "Publishing to ${GITHUB_REPOSITORY}"
 
 site_url=${INPUT_SITE_URL}
 if [[ "${site_url}" == "" ]]; then
@@ -68,28 +87,28 @@ print_info "Using site URL ${site_url}"
 
 PUBLISH_REPOSITORY=${GITHUB_REPOSITORY}
 PUBLISH_BRANCH=gh-pages
-PUBLISH_DIR=`grep 'site_dir:' mkdocs.yml | awk '{print $2}'`
+PUBLISH_DIR=$(grep 'site_dir:' mkdocs.yml | awk '{print $2}')
 
 print_info "Deploy to ${PUBLISH_REPOSITORY}@${PUBLISH_BRANCH} from directory ${PUBLISH_DIR}"
 
 print_info "Cloning documentation theme"
-git clone git://github.com/laminas/documentation-theme.git ${GITHUB_WORKSPACE}/documentation-theme
+git clone git://github.com/laminas/documentation-theme.git "${GITHUB_WORKSPACE}/documentation-theme"
 
 print_info "Building documentation"
-(cd ${GITHUB_WORKSPACE} ; ./documentation-theme/build.sh -u ${site_url})
+(cd "${GITHUB_WORKSPACE}" ; ./documentation-theme/build.sh -u "${site_url}")
 
 print_info "Deploying documentation"
 remote_branch="${PUBLISH_BRANCH}"
 local_dir="${HOME}/ghpages_${RANDOM}"
 
 if git clone --depth=1 --single-branch --branch "${remote_branch}" "${remote_repo}" "${local_dir}"; then
-    print_info "- Cloning branch ${remote_branch} from ${remote_repo} to ${local_dir} and removing previous files"
+    print_info "- Cloning branch ${remote_branch} from ${GITHUB_REPOSITORY} to ${local_dir} and removing previous files"
     cd "${local_dir}"
 
     git rm -r --ignore-unmatch '*'
 else
-    print_info "- Creating new ${remote_branch} branch on ${remote_repo} in ${local_dir}"
-    git clone --depth=1 --single-branch --branch master "${remote_repo}" "${local_dir}"
+    print_info "- Creating new ${remote_branch} branch on ${GITHUB_REPOSITORY} in ${local_dir}"
+    git clone --depth=1 --single-branch "${remote_repo}" "${local_dir}"
     cd "${local_dir}"
     git checkout --orphan "${remote_branch}"
     git rm -rf .
@@ -110,14 +129,14 @@ if [[ -n "${INPUT_USEREMAIL}" ]]; then
 else
     cd "${local_dir}" && git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 fi
-cd "${local_dir}" && git remote rm origin || true
+(cd "${local_dir}" && git remote rm origin) || true
 cd "${local_dir}" && git remote add origin "${remote_repo}"
 cd "${local_dir}" && git add --all
 
 print_info "Allowing empty commits: ${INPUT_EMPTYCOMMITS}"
 COMMIT_MESSAGE="Automated deployment: $(date -u) ${WHAT_DO_WE_BUILD}"
 if [[ ${INPUT_EMPTYCOMMITS} == "false" ]]; then
-    cd "${local_dir}" && git commit -m "${COMMIT_MESSAGE}" || skip
+    (cd "${local_dir}" && git commit -m "${COMMIT_MESSAGE}") || skip
 else
     cd "${local_dir}" && git commit --allow-empty -m "${COMMIT_MESSAGE}"
 fi


### PR DESCRIPTION
In reviewing issues with documentation publication via the docs-build action, the problem appears to be with permissions to checkout and/or push to the source repository running the action.
This is a solved problem with laminas/automatic-releases: you can use git over HTTPS with a privileged GitHub OAuth token (generally in the ORGANIZATION_ADMIN_TOKEN organization-level secret).

This patch modifies the setup of the "remote_repo" variable in a backwards-compatible way.
If a DEPLOY_TOKEN is present in the workflow env (e.g. `DEPLOY_TOKEN: {{ secrets.ORGANIZATION_ADMIN_TOKEN }}`), then this will be used to construct a git+HTTPS URL with the token.
If a DOCS_DEPLOY_KEY is present in the workflow env (current usage), it will set it up as the root user SSH key.
Otherwise, it will fail (same as current behavior).

An example workflow file thus changes from this:

```yaml
name: docs-build

on:
  release:
    types: [published]
  repository_dispatch:
    types: docs-build

jobs:
  build-deploy:
    runs-on: ubuntu-latest
    steps:
      - name: Build and deploy documentation
        uses: laminas/documentation-theme/github-actions/docs@master
        env:
          DEPLOY_DEPLOY_KEY: ${{ secrets.DOCS_DEPLOY_KEY }}
        with:
          emptyCommits: false
```

to this:

```yaml
name: docs-build

on:
  release:
    types: [published]
  repository_dispatch:
    types: docs-build

jobs:
  build-deploy:
    runs-on: ubuntu-latest
    steps:
      - name: Build and deploy documentation
        uses: laminas/documentation-theme/github-actions/docs@master
        env:
          DEPLOY_TOKEN: ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
        with:
          emptyCommits: false
```

(Note: only the `env` section changs between the two workflows.)

This allows repositories to opt-in to the new behavior, allowing us to test and refine it, without breaking usage for existing repositories.

While performing these changes, shellcheck flagged some potentially unsafe or erroneous syntax, which I have also fixed (primarily lack of quoting when using variables, and failure to wrap the left side of A && B || C statements in parens).

I have also documented usage updates in the readme.
