### PR TITLE
Adds definition lists to markdown extensions

### DIFF
--- a/update_mkdocs_yml.py
+++ b/update_mkdocs_yml.py
@@ -24,6 +24,7 @@ mkdocs["markdown_extensions"] = [
         },
         "markdown.extensions.attr_list",
         "markdown.extensions.md_in_html",
+        "markdown.extensions.def_list",
         "pymdownx.superfences",
         "pymdownx.tabbed",
         {


### PR DESCRIPTION
Reference: https://python-markdown.github.io/extensions/definition_lists/

