### PR TITLE
[Fix] PAGES: homepage.html broken issues url

### DIFF
--- a/theme/pages/homepage.html
+++ b/theme/pages/homepage.html
@@ -15,7 +15,7 @@
 
 <h2>Support</h2>
 <ul>
-    <li>Issues: <a href="{{ config.repo_url }}issues">{{ config.repo_url|replace('https://', '') }}issues</a></li>
+    <li>Issues: <a href="{{ config.repo_url }}/issues">{{ config.repo_url|replace('https://', '') }}/issues</a></li>
     <li>Source: <a href="{{ config.repo_url }}">{{ config.repo_url|replace('https://', '') }}</a></li>
     <li>Chat: <a href="https://laminas.dev/chat">laminas.dev/chat</a></li>
     <li>Forum: <a href="https://discourse.laminas.dev/">discourse.laminas.dev</a></li>

--- a/update_mkdocs_yml.py
+++ b/update_mkdocs_yml.py
@@ -43,7 +43,7 @@ mkdocs["theme"] = {
         ]
     }
 
-mkdocs["extra"]["repo_name"] = mkdocs["repo_url"].replace("https://github.com/", "")
+mkdocs["extra"]["repo_name"] = mkdocs["repo_url"].replace("https://github.com/", "").rstrip("/")
 mkdocs["extra"]["base_url"] = "https://docs.laminas.dev/"
 
 if mkdocs["extra"]["project"] == "Components":


### PR DESCRIPTION
Signed-off-by: Remy Bos <27890746+sjokkateer@users.noreply.github.com>

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
This PR attempts to fix an issue where the url to the issues page of the repository of a particular laminas component is broken.

Pages with a broken issues URL:

- [laminas-di](https://docs.laminas.dev/laminas-di/)
- [laminas-log](https://docs.laminas.dev/laminas-log/)
- [laminas-diactoros](https://docs.laminas.dev/laminas-diactoros/)

What I've done:
- Manually check each [laminas component](https://docs.laminas.dev/components/) and opened their documentation homepage.
- Open every component's `mkdocs.yml` file in the repo and inspect the `repo_url` property for trailing slashes.

What I've discovered:
- All sites that don't have the broken URL have a trailing slash at the URL for `Source`, one example: [laminas-cache](https://docs.laminas.dev/laminas-cache/). 
- All sites that don't have the broken issue URL have no trailing slash in their `mkdocs.yml` file, one example: [laminas-cache#L39](https://github.com/laminas/laminas-cache/blob/3.2.x/mkdocs.yml#L39)

What I've concluded:
The components that don't have the broken URL are either cached or some caching is applied somewhere in the build process. Although the same error does not apply to the other component's homepage (yet) this will most likely apply at some point in the future.

Please let me know what you think of the 'investigation' and proposed change. And whether or not it is possible to freshly rebuild the documentations after the change takes effect?

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
