### PR TITLE
Adds PyMdown extension Snippets to MkDocs update script

### DIFF
--- a/update_mkdocs_yml.py
+++ b/update_mkdocs_yml.py
@@ -28,6 +28,14 @@ mkdocs["markdown_extensions"] = [
         "pymdownx.superfences",
         "pymdownx.tabbed",
         {
+            "pymdownx.snippets": {
+                "url_download": True,
+                "base_path": [
+                    "docs/snippets"
+                ]
+            }
+        },
+        {
             "toc": {
                 "toc_depth": 2
             }


### PR DESCRIPTION
The snippets support is provided by the PyMdown Extension:

> Snippets is an extension to insert markdown or HTML snippets into another markdown file.

https://facelessuser.github.io/pymdown-extensions/extensions/snippets/

This pull request adds the configuration to allow adding snippets via URL and adds a base path for snippets: 

- https://facelessuser.github.io/pymdown-extensions/extensions/snippets/#url-snippet
- https://facelessuser.github.io/pymdown-extensions/extensions/snippets/#options