### PR TITLE
Updates do-we-build-and-if-so-what script to user and prefer `DEPLOY_TOKEN`

### DIFF
--- a/github-actions/docs/do-we-build-and-if-so-what.php
+++ b/github-actions/docs/do-we-build-and-if-so-what.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 $event = getenv('GITHUB_EVENT_NAME') ?: '';
 $ref   = preg_replace('#^refs/(tags|heads)/#', '', getenv('GITHUB_REF') ?: '');
 $repo  = getenv('GITHUB_REPOSITORY');
-$token = getenv('GITHUB_TOKEN');
+$token = getenv('DEPLOY_TOKEN') ?: getenv('GITHUB_TOKEN');
 
 /*
  * FUNCTIONS


### PR DESCRIPTION
The example in the readme says to use `DEPLOY_TOKEN` but the `do-we-build-and-if-so-what.php` still requires `GITHUB_TOKEN`:

https://github.com/laminas/documentation-theme/blob/4570714d8549ffd59144dc5cde5745bb006baa4c/github-actions/docs/do-we-build-and-if-so-what.php#L11

```yaml
name: docs-build

on:
  release:
    types: [published]
  repository_dispatch:
    types: docs-build

jobs:
  build-deploy:
    runs-on: ubuntu-latest
    steps:
      - name: Build and deploy documentation
        uses: laminas/documentation-theme/github-actions/docs@master
        env:
          DEPLOY_TOKEN: ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
        with:
          emptyCommits: false
```

https://github.com/laminas/documentation-theme/tree/master/github-actions/docs#example-workflow