### PR TITLE
Use token authentication

### DIFF
--- a/github-actions/docs/entrypoint.sh
+++ b/github-actions/docs/entrypoint.sh
@@ -26,7 +26,7 @@ function skip() {
 function remote_repo_setup() {
     local -n RESULT=$1
     local DEPLOY_TOKEN=$2
-    RESULT="https://${DEPLOY_TOKEN}:x-oauth-basic@github.com/${GITHUB_REPOSITORY}.git"
+    RESULT="https://${DEPLOY_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 }
 
 function remote_repo_setup_legacy() {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Github has deprecated basic authentication.
The appropriate way to pull and push when using HTTPS is to either:

- include the token via a header
- include the token **ONLY** in the user-info of the URL

The latter works with git remotes as defined in git configuration (tested and verified with a private repository).
This patch updates to that usage in the remote_repo_setup function.

Unknown if this will solve the issue definitively, but it does correct a known error.
