### PR TITLE
Use x-access-token format

### DIFF
--- a/github-actions/docs/entrypoint.sh
+++ b/github-actions/docs/entrypoint.sh
@@ -26,7 +26,7 @@ function skip() {
 function remote_repo_setup() {
     local -n RESULT=$1
     local DEPLOY_TOKEN=$2
-    RESULT="https://${DEPLOY_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+    RESULT="https://x-access-token:${DEPLOY_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 }
 
 function remote_repo_setup_legacy() {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

As documented here: https://stackoverflow.com/a/58393457

In place of basic auth details, you can use `x-access-token:${token}`. Since we saw an issue with usage of the action that detailed "could not read Password for ...", this may be the solution.

Again, tested using this to both pull and push to a private repository, and encountered no issues.
