### PR TITLE
Replaces the Twitter link in the footer with a link to Mastodon and updates CSS classes for brands

### DIFF
--- a/theme/partials/footer.html
+++ b/theme/partials/footer.html
@@ -38,7 +38,7 @@
                                 <a href="https://github.com/laminas" class="support__link" title="Github"><i class="fa fa-github"></i></a>
                             </li>
                             <li class="support__list-item">
-                                <a href="https://twitter.com/getlaminas" class="support__link" title="Twitter"><i class="fa fa-twitter"></i></a>
+                                <a href="https://phpc.social/@getlaminas" class="support__link" title="Mastodon"><i class="fab fa-mastodon"></i></a>
                             </li>
                             <li class="support__list-item">
                                 <a href="https://getlaminas.org/blog/rss.xml" class="support__link" title="Blog feed"><i class="fa fa-rss"></i></a>

--- a/theme/partials/footer.html
+++ b/theme/partials/footer.html
@@ -32,10 +32,10 @@
                                 <a href="https://discourse.laminas.dev" class="support__link" title="Forum"><i class="fa fa-comments"></i></a>
                             </li>
                             <li class="support__list-item">
-                                <a href="https://laminas.dev/chat" class="support__link" title="Chat"><i class="fa fa-slack"></i></a>
+                                <a href="https://laminas.dev/chat" class="support__link" title="Chat"><i class="fab fa-slack"></i></a>
                             </li>
                             <li class="support__list-item">
-                                <a href="https://github.com/laminas" class="support__link" title="Github"><i class="fa fa-github"></i></a>
+                                <a href="https://github.com/laminas" class="support__link" title="Github"><i class="fab fa-github"></i></a>
                             </li>
                             <li class="support__list-item">
                                 <a href="https://phpc.social/@getlaminas" class="support__link" title="Mastodon"><i class="fab fa-mastodon"></i></a>

--- a/theme/partials/header.html
+++ b/theme/partials/header.html
@@ -22,7 +22,7 @@
                         <i class="fa fa-search"></i> Search
                     </a>
                     <a href="{{ config.repo_url }}" class="header__link header__link--github" title="Go to repository of {{ config.site_name }}">
-                        <i class="fa fa-github"></i> GitHub
+                        <i class="fab fa-github"></i> GitHub
                     </a>
                 {% endif %}
             </div>


### PR DESCRIPTION
Blocked by https://github.com/laminas/laminas.github.io/pull/229