### PR TITLE
Add mkdocs-yamp to Dockerfile dependencies

### DIFF
--- a/github-actions/docs/Dockerfile
+++ b/github-actions/docs/Dockerfile
@@ -22,7 +22,7 @@ RUN cd /usr/bin \
   && ln -sf pip3 pip
 
 RUN pip install nltk==3.4.5
-RUN pip install mkdocs pyaml pymdown-extensions mkdocs-redirects markdown-callouts
+RUN pip install mkdocs pyaml pymdown-extensions mkdocs-redirects markdown-callouts mkdocs-yamp
 
 COPY entrypoint.sh /usr/bin/entrypoint.sh
 COPY do-we-build-and-if-so-what.php /usr/bin/do-we-build-and-if-so-what.php


### PR DESCRIPTION
> This plugin allows users to define external repositories for integration into the MkDocs site.

https://github.com/boozallen/mkdocs-yamp-plugin