### PR TITLE
Add GitHub token support to documentation scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,12 +24,14 @@ function help() {
     echo "Options:"
     echo "  -h           Usage help; this message."
     echo "  -u <url>     Deployment URL of documentation (to ensure search works)"
+    echo "  -t           GitHub Token"
 }
 
 while getopts hu: option;do
     case "${option}" in
         h) help && exit 0;;
         u) SITE_URL=${OPTARG};;
+        t) GH_TOKEN=${OPTARG};;
     esac
 done
 
@@ -40,7 +42,7 @@ DOC_DIR=$(dirname ${DOCS_DIR})
 
 # Update the mkdocs.yml
 echo "Building documentation in ${DOC_DIR}"
-${SCRIPT_PATH}/update_mkdocs_yml.py ${SITE_URL} ${DOCS_DIR}
+${SCRIPT_PATH}/update_mkdocs_yml.py ${SITE_URL} ${DOCS_DIR} ${GH_TOKEN}
 
 # Preserve files if necessary (as mkdocs build --clean removes all files)
 if [ -e .laminas-mkdoc-theme-preserve ]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -74,7 +74,7 @@ mkdir -p ${DOC_DIR}/html
 )
 
 # Build the documentation
-${SCRIPT_PATH}/build.sh -u ${SITE_URL}
+${SCRIPT_PATH}/build.sh -u ${SITE_URL} ${GH_TOKEN}
 
 # Commit and push the documentation to gh-pages
 (

--- a/github-actions/docs/entrypoint.sh
+++ b/github-actions/docs/entrypoint.sh
@@ -95,7 +95,7 @@ print_info "Cloning documentation theme"
 git clone https://github.com/laminas/documentation-theme.git "${GITHUB_WORKSPACE}/documentation-theme"
 
 print_info "Building documentation"
-(cd "${GITHUB_WORKSPACE}" ; ./documentation-theme/build.sh -u "${site_url}")
+(cd "${GITHUB_WORKSPACE}" ; ./documentation-theme/build.sh -u "${site_url}" -t "${DEPLOY_TOKEN}")
 
 print_info "Deploying documentation"
 remote_branch="${PUBLISH_BRANCH}"

--- a/update_mkdocs_yml.py
+++ b/update_mkdocs_yml.py
@@ -10,6 +10,7 @@ if len(sys.argv) < 3:
 
 site_url = sys.argv[1]
 docs_dir = sys.argv[2]
+token = sys.argv[3]
 
 with open("mkdocs.yml") as f:
     mkdocs = yaml.load(f, Loader=yaml.SafeLoader)


### PR DESCRIPTION
The scripts for processing documentation, including `build.sh`, `update_mkdocs.yml`, `entrypoint.sh`, and `deploy.sh`, have been updated to support passing a GitHub token. This addition enhances security and access control in documentation builds and deploys.