### PR TITLE
Add maintenance overview link to footer

### DIFF
--- a/theme/partials/footer.html
+++ b/theme/partials/footer.html
@@ -16,6 +16,7 @@
                     <li>Laminas Components and MVC <a href="https://docs.laminas.dev/">Components and MVC for enterprise applications</a></li>
                     <li>Mezzio <a href="https://docs.mezzio.dev/">PSR-15 middleware in minutes</a></li>
                     <li>Laminas API Tools <a href="https://api-tools.getlaminas.org/">Build RESTful APIs in minutes</a></li>
+                    <li>Maintenance Overview <a href="https://getlaminas.org/packages-maintenance-status/">Current maintenance status of Laminas &amp; Mezzio packages</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
Updated the footer to include a link to the current maintenance status of Laminas & Mezzio packages. This provides users with quick access to important maintenance information.