### PR TITLE
Add builder Dockerfile

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3-alpine
+
+RUN pip install --upgrade pip
+
+# PHP and bash are required for the theme installer
+
+RUN apk update \
+    && apk upgrade --no-cache \
+    && apk add --no-cache \
+    php \
+    bash
+
+# Install markdown with required libs and plugins
+RUN pip install \
+    pyyaml \
+    markdown \
+    mkdocs \
+    pymdown-extensions \
+    markdown-callouts \
+    mkdocs-redirects


### PR DESCRIPTION
This will provide users with a way of getting `mkdocs` up and running quickly.

For example, after cloning this repo:

`cd documentation-theme/builder && docker build -t laminas/mkdocs .`

