### PR TITLE
Refactor site name rendering to support badge inclusion for abandoned components

### DIFF
--- a/theme/pages/homepage.html
+++ b/theme/pages/homepage.html
@@ -1,4 +1,7 @@
-<h1>{{ config.site_name }}</h1>
+<h1>
+    {% set show_badge = true %}
+    {% include "partials/site-name.html" %}
+</h1>
 <p>{{ config.site_description }}</p>
 
 {% if config.extra.show_special_homepage %}

--- a/theme/partials/breadcrumb.html
+++ b/theme/partials/breadcrumb.html
@@ -5,7 +5,11 @@
             <li class="breadcrumb-item"><a href="{{ config.extra.project_url }}">{{ config.extra.project }}</a></li>
 
             {% if page.title != 'Home' %}
-                <li class="breadcrumb-item"><a href="{{ nav.homepage.url|url }}">{{ config.site_name }}</a></li>
+                <li class="breadcrumb-item">
+                    <a href="{{ nav.homepage.url|url }}">
+                        {% include "partials/site-name.html" %}
+                    </a>
+                </li>
 
                 {% for doc in page.ancestors|reverse %}
                     {% if doc.link %}
@@ -21,7 +25,9 @@
 
                 <li class="breadcrumb-item active" aria-current="page">{{ page.title }}</li>
             {% else %}
-                <li class="breadcrumb-item">{{ config.site_name }}</li>
+                <li class="breadcrumb-item">
+                    {% include "partials/site-name.html" %}
+                </li>
             {% endif %}
         {% else %}
             <li class="breadcrumb-item">Overview</li>

--- a/theme/partials/header.html
+++ b/theme/partials/header.html
@@ -8,7 +8,10 @@
                     {{ config.extra.project }}
 
                     {% if config.site_name != 'Laminas Docs' %}
-                        <small class="header__subtitle">{{ config.site_name }}</small>
+                        <small class="header__subtitle">
+                            {% set show_badge = true %}
+                            {% include "partials/site-name.html" %}
+                        </small>
                     {% endif %}
                 </h1>
             </div>

--- a/theme/partials/site-name.html
+++ b/theme/partials/site-name.html
@@ -1,0 +1,9 @@
+{% if 'abandoned' in config.site_name|lower %}
+    {{ config.site_name|replace('(Abandoned)', '')|replace('(abandoned)', '') }}
+
+    {% if show_badge %}
+        <span class="badge badge-warning">abandoned</span>
+    {% endif %}
+{% else %}
+    {{ config.site_name }}
+{% endif %}

--- a/theme/partials/subnavigation.html
+++ b/theme/partials/subnavigation.html
@@ -1,7 +1,10 @@
 {% if nav|length > 1 %}
     <div class="subnavigation hidden-print">
         <h4 class="subnavigation__title">
-            <a href="{{ nav.homepage.url|url }}">{{ config.site_name }}</a>
+            <a href="{{ nav.homepage.url|url }}">
+                {% set show_badge = true %}
+                {% include "partials/site-name.html" %}
+            </a>
         </h4>
 
         <h5 class="subnavigation__subtitle">Table of Contents</h5>


### PR DESCRIPTION
Support conditional formatting of the site name to exclude "(Abandoned)" text and display a badge instead when applicable. This ensures a consistent and clear visual indication of abandoned projects across the site's breadcrumb, header, homepage, and subnavigation sections.

## Example

![abandoned](https://github.com/user-attachments/assets/622b2d94-bd32-4193-b60d-e553c7723480)
