### PR TITLE
Add abandoned package notification to site pages

### DIFF
--- a/theme/pages/homepage.html
+++ b/theme/pages/homepage.html
@@ -4,6 +4,9 @@
 </h1>
 <p>{{ config.site_description }}</p>
 
+{# Notification of abandoned package #}
+{% include "partials/abandoned-notice.html" %}
+
 {% if config.extra.show_special_homepage %}
     {{ page.content }}
 

--- a/theme/pages/installation.html
+++ b/theme/pages/installation.html
@@ -20,6 +20,9 @@
     </ul>
 </div>
 
+{# Notification of abandoned package #}
+{% include "partials/abandoned-notice.html" %}
+
 {# Standard Installation #}
 <h2 id="standard-installation">Standard Installation</h2>
 <p>To install the library use <a href="https://getcomposer.org/">Composer</a>:</p>

--- a/theme/partials/abandoned-notice.html
+++ b/theme/partials/abandoned-notice.html
@@ -1,0 +1,6 @@
+{% if 'abandoned' in config.site_name|lower %}
+    <div class="admonition caution">
+        <p class="admonition-title">Caution</p>
+        <p>This package is abandoned and will receive no further development.</p>
+    </div>
+{% endif %}


### PR DESCRIPTION
Included a notice in both the installation and homepage to inform users when a package is abandoned. This notice is based on the condition that 'abandoned' is present in the lowercase form of the site name. It aims to clearly communicate to users that the package will not receive further updates or development.
The message does not contain a link or a reference to alternatives so that it does not become more complicated.